### PR TITLE
added running count of files parsed 

### DIFF
--- a/.gutenignore
+++ b/.gutenignore
@@ -1,1 +1,1 @@
-node_modules
+node_modules/*

--- a/src/parser/extract.js
+++ b/src/parser/extract.js
@@ -68,6 +68,7 @@ const exclude = (address, ROOT) => {
 
 const walk = (searchPath, ROOT) => {
   const result = [];
+  let fileCount = 0;
   const unReadableFiles = [];
   return exclude(searchPath, ROOT).then(list => new Promise((resolve, reject) => klaw(searchPath)
     .on('data', (item) => {
@@ -82,6 +83,10 @@ const walk = (searchPath, ROOT) => {
         } catch (error) {
           unReadableFiles.push(path.basename(item.path));
         }
+        fileCount += 1;
+        process.stdout.clearLine();
+        process.stdout.cursorTo(0);
+        process.stdout.write(`Files Processed: ${fileCount}`);
         result.push(tag);
       }
     })
@@ -90,11 +95,15 @@ const walk = (searchPath, ROOT) => {
     })
     .on('end', () => {
       resolve(result);
+      process.stdout.write("\n");
       if (unReadableFiles.length !== 0) {
         /* eslint-disable-next-line no-console */
-        console.log('The following files were unparable, and ommited from parsing:');
+        console.log(`${unReadableFiles.lenth} files were unpasable, and ommited from parsing:`);
         /* eslint-disable-next-line no-console */
         unReadableFiles.forEach(fileName => console.log(fileName));
+      } else {
+        /* eslint-disable-next-line no-console */
+        console.log('No unignored .js or .jsx files were unparsable');
       }
     })));
 };

--- a/src/parser/extract.js
+++ b/src/parser/extract.js
@@ -68,6 +68,7 @@ const exclude = (address, ROOT) => {
 
 const walk = (searchPath, ROOT) => {
   const result = [];
+  let badFile = false;
   let fileCount = 0;
   const unReadableFiles = [];
   return exclude(searchPath, ROOT).then(list => new Promise((resolve, reject) => klaw(searchPath)
@@ -82,6 +83,7 @@ const walk = (searchPath, ROOT) => {
           acornParse(content, tag.content);
         } catch (error) {
           unReadableFiles.push(path.basename(item.path));
+          badFile = true;
         }
         fileCount += 1;
         process.stdout.clearLine();
@@ -89,7 +91,10 @@ const walk = (searchPath, ROOT) => {
         process.stdout.write(`Files Processed: ${fileCount}`);
         process.stdout.cursorTo(25);
         process.stdout.write(item.path.replace(ROOT, './').slice(0, 60));
-        result.push(tag);
+        if (!badFile) {
+          result.push(tag);
+        }
+        badFile = false;
       }
     })
     .on('error', (err) => {

--- a/src/parser/extract.js
+++ b/src/parser/extract.js
@@ -87,6 +87,8 @@ const walk = (searchPath, ROOT) => {
         process.stdout.clearLine();
         process.stdout.cursorTo(0);
         process.stdout.write(`Files Processed: ${fileCount}`);
+        process.stdout.cursorTo(25);
+        process.stdout.write(item.path.replace(ROOT, './').slice(0, 60));
         result.push(tag);
       }
     })

--- a/src/parser/extract.js
+++ b/src/parser/extract.js
@@ -95,7 +95,7 @@ const walk = (searchPath, ROOT) => {
     })
     .on('end', () => {
       resolve(result);
-      process.stdout.write("\n");
+      process.stdout.write('\n');
       if (unReadableFiles.length !== 0) {
         /* eslint-disable-next-line no-console */
         console.log(`${unReadableFiles.lenth} files were unpasable, and ommited from parsing:`);

--- a/src/parser/parseComments.js
+++ b/src/parser/parseComments.js
@@ -10,6 +10,8 @@ const errors = require('./utils/errors.js');
  */
 
 const saveTags = (data, path) => {
+  // TODO : i think there needs to be another escape handling added here to be 
+  // TODOv: able to parse comments that contain backticks
   const dataToSave = JSON.stringify(data).replace(/\\n/g, '\\\\n');
   fs.writeFile(path, parseCommentsTemplate(dataToSave), (err) => {
     if (err) {

--- a/src/parser/parseComments.js
+++ b/src/parser/parseComments.js
@@ -10,7 +10,7 @@ const errors = require('./utils/errors.js');
  */
 
 const saveTags = (data, path) => {
-  // TODO : i think there needs to be another escape handling added here to be 
+  // TODO : i think there needs to be another escape handling added here to be
   // TODOv: able to parse comments that contain backticks
   const dataToSave = JSON.stringify(data).replace(/\\n/g, '\\\\n');
   fs.writeFile(path, parseCommentsTemplate(dataToSave), (err) => {


### PR DESCRIPTION
as well as output of files that were unparsable

now when you call "guten --all"

it will tell you how many files have been parsed while parsing

upon completion, it will also tell you how many you were unsuccessful at parsing.

This branch needs to be merged separately from the other PR that I did.  Both were rebased prior to submitting the PR but neither one contains the code from the other.