### PR TITLE
abstracted the questions into a separate file for inquirer prompts

### DIFF
--- a/src/inquirerOptions.js
+++ b/src/inquirerOptions.js
@@ -1,0 +1,33 @@
+const corruptFilePrompt = fileName => [
+  {
+    type: 'confirm',
+    name: 'delete',
+    message: `Your ${fileName} file seems to no longer be a valid file.\n`
+    + 'Can I erase the existing file and replace it with the default?',
+    default: false,
+  },
+];
+
+const confirmDeletePrompt = (fileName) => {
+  const option1 = `I changed my mind, dont delete my ${fileName}`;
+  const option2 = `Save a backup file for your current version of ${fileName}`;
+  const option3 = 'Just overwrite it.';
+
+  const questions = [
+    {
+      type: 'list',
+      name: 'method',
+      message: 'You could lose the information currently in the file.\n'
+      + 'Are you sure you want to overwrite it?',
+      choices: [
+        option1,
+        option2,
+        option3,
+      ],
+    },
+  ];
+  return { questions, options: [option1, option2, option3] };
+};
+
+module.exports.confirmDeletePrompt = confirmDeletePrompt;
+module.exports.corruptFilePrompt = corruptFilePrompt;


### PR DESCRIPTION
When I refactored the text to display in the question prompt to be more clear about it creating a backup file I failed to also update the conditionals that check which option was selected. 

TL;DR - my code wasn't DRY before and I broke the functionality because I only change the text in one place

I fixed this by moving the action content of the prompts to an outside file called inquirerquestions.js and then had it content functions the took in a filename as a param and returned a question and an array of options that will always match.  So not if you want to update the questions/options you just have to do it in one place.