### PR TITLE
Include a "Clean AST Function" (not yet implemented in CLI.js)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -124,8 +124,9 @@ yargs.parse(process.argv.slice(2), (err, argv, output) => {
       // const exclude = fs.readFileSync(`${pathData.absPath}/.gutenignore`, 'utf8').split('\n');
       extract(['./']).then((data) => {
         const ast = parseComments(data, address);
-        const dataToWrite = execSorts(ast);
-        saveTags(dataToWrite, address);
+        cleanAST(ast);
+        // const dataToWrite = execSorts(ast);
+        // saveTags(dataToWrite, address);
       });
     }
   }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,7 +15,7 @@ const {
   refreshAPI,
   generateAPIFrame,
 } = require('../src/utils.js');
-const { execSorts, cleanAST } = require('../src/sorters/execSorts.js');
+const { execSorts } = require('../src/sorters/execSorts.js');
 const { saveTags } = require('../src/parser/saveTags.js');
 
 yargs.usage(`$0 ${
@@ -124,9 +124,8 @@ yargs.parse(process.argv.slice(2), (err, argv, output) => {
       // const exclude = fs.readFileSync(`${pathData.absPath}/.gutenignore`, 'utf8').split('\n');
       extract(['./']).then((data) => {
         const ast = parseComments(data, address);
-        cleanAST(ast);
-        // const dataToWrite = execSorts(ast);
-        // saveTags(dataToWrite, address);
+        const dataToWrite = execSorts(ast);
+        saveTags(dataToWrite, address);
       });
     }
   }
@@ -160,9 +159,8 @@ yargs.parse(process.argv.slice(2), (err, argv, output) => {
       if (missingFiles.length === 0) {
         extract(argv._).then((data) => {
           const ast = parseComments(data, address);
-          cleanAST(ast);
-          // const dataToWrite = execSorts(ast);
-          // saveTags(dataToWrite, address);
+          const dataToWrite = execSorts(ast);
+          saveTags(dataToWrite, address);
         });
       }
     }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,8 +15,8 @@ const {
   refreshAPI,
   generateAPIFrame,
 } = require('../src/utils.js');
-const { execSorts } = require('../src/sorters/execSorts.js');
-const { saveTags, cleanAST } = require('../src/parser/saveTags.js');
+const { execSorts, cleanAST } = require('../src/sorters/execSorts.js');
+const { saveTags } = require('../src/parser/saveTags.js');
 
 yargs.usage(`$0 ${
   pjson.version

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -16,7 +16,7 @@ const {
   generateAPIFrame,
 } = require('../src/utils.js');
 const { execSorts } = require('../src/sorters/execSorts.js');
-const { saveTags } = require('../src/parser/saveTags.js');
+const { saveTags, cleanAST } = require('../src/parser/saveTags.js');
 
 yargs.usage(`$0 ${
   pjson.version
@@ -159,8 +159,9 @@ yargs.parse(process.argv.slice(2), (err, argv, output) => {
       if (missingFiles.length === 0) {
         extract(argv._).then((data) => {
           const ast = parseComments(data, address);
-          const dataToWrite = execSorts(ast);
-          saveTags(dataToWrite, address);
+          cleanAST(ast);
+          // const dataToWrite = execSorts(ast);
+          // saveTags(dataToWrite, address);
         });
       }
     }

--- a/src/parser/saveTags.js
+++ b/src/parser/saveTags.js
@@ -10,34 +10,4 @@ const saveTags = (data, path) => {
   });
 };
 
-const cleanAST = (ast) => {
-  const commentBlocks = [];
-
-  ast.forEach((file) =>{
-    file.content.forEach((commentBlock) => {
-      // const updatedCommentBlock = {};
-      // updatedCommentBlock.description = commentBlock.description;
-      // updatedCommentBlock.tags = commentBlock.tags;
-      // updatedCommentBlock.name = commentBlock.name;   
-      // updatedCommentBlock.header = undefined;
-      // updatedCommentBlock.priority = undefined;  
-      commentBlocks.push({
-        header: undefined,
-        priority: undefined,
-        description: commentBlock.description,
-        tags: commentBlock.tags,
-        name: commentBlock.name,
-        pathName: file.fileName,
-      });
-    });
-  });
-  
-  for (let i = 0; i < commentBlocks.length; i++) {
-    console.log('*************************');
-    console.log(commentBlocks[i]);
-  }
-  return commentBlocks;
-};
-
 module.exports.saveTags = saveTags;
-module.exports.cleanAST = cleanAST;

--- a/src/parser/saveTags.js
+++ b/src/parser/saveTags.js
@@ -10,4 +10,14 @@ const saveTags = (data, path) => {
   });
 };
 
+const cleanAST = (ast) => {
+  // console.log('this ast is', JSON.stringify(ast));
+
+  //iterate through each file
+  ast.forEach((file) =>{
+    console.log('FileName====>>>>', file.fileName);
+  });
+};
+
 module.exports.saveTags = saveTags;
+module.exports.cleanAST = cleanAST;

--- a/src/parser/saveTags.js
+++ b/src/parser/saveTags.js
@@ -15,23 +15,27 @@ const cleanAST = (ast) => {
 
   ast.forEach((file) =>{
     file.content.forEach((commentBlock) => {
-      const updatedCommentBlock = {};
-      updatedCommentBlock.description = commentBlock.description;
-      updatedCommentBlock.tags = commentBlock.tags;
-      updatedCommentBlock.name = commentBlock.name;   
-      updatedCommentBlock.header = undefined;
-      updatedCommentBlock.priority = undefined;
-      // commentBlocks.push(updatedCommentBlock);
-      console.log(file.fileName);      
-      // commentBlocks.push({
-      //   description: commentBlock.description,
-      //   tags: commentBlock.tags,
-      //   name: commentBlock.name,
-      //   path: 
-      // });
+      // const updatedCommentBlock = {};
+      // updatedCommentBlock.description = commentBlock.description;
+      // updatedCommentBlock.tags = commentBlock.tags;
+      // updatedCommentBlock.name = commentBlock.name;   
+      // updatedCommentBlock.header = undefined;
+      // updatedCommentBlock.priority = undefined;  
+      commentBlocks.push({
+        header: undefined,
+        priority: undefined,
+        description: commentBlock.description,
+        tags: commentBlock.tags,
+        name: commentBlock.name,
+        pathName: file.fileName,
+      });
     });
   });
-
+  
+  for (let i = 0; i < commentBlocks.length; i++) {
+    console.log('*************************');
+    console.log(commentBlocks[i]);
+  }
   return commentBlocks;
 };
 

--- a/src/parser/saveTags.js
+++ b/src/parser/saveTags.js
@@ -11,12 +11,28 @@ const saveTags = (data, path) => {
 };
 
 const cleanAST = (ast) => {
-  // console.log('this ast is', JSON.stringify(ast));
+  const commentBlocks = [];
 
-  //iterate through each file
   ast.forEach((file) =>{
-    console.log('FileName====>>>>', file.fileName);
+    file.content.forEach((commentBlock) => {
+      const updatedCommentBlock = {};
+      updatedCommentBlock.description = commentBlock.description;
+      updatedCommentBlock.tags = commentBlock.tags;
+      updatedCommentBlock.name = commentBlock.name;   
+      updatedCommentBlock.header = undefined;
+      updatedCommentBlock.priority = undefined;
+      // commentBlocks.push(updatedCommentBlock);
+      console.log(file.fileName);      
+      // commentBlocks.push({
+      //   description: commentBlock.description,
+      //   tags: commentBlock.tags,
+      //   name: commentBlock.name,
+      //   path: 
+      // });
+    });
   });
+
+  return commentBlocks;
 };
 
 module.exports.saveTags = saveTags;

--- a/src/parser/utils/errors.js
+++ b/src/parser/utils/errors.js
@@ -4,6 +4,11 @@ const parseCommentsArrayErr = (filesArray) => {
   }
 };
 
+/**
+ * @description error test description
+ * @param someparam {[]} some ereror tst param
+ */
+
 const parseCommentsFileErr = (file) => {
   if (!(file instanceof Object)) {
     throw new TypeError('Array passed to parseComments should contain strings');

--- a/src/sorters/execSorts.js
+++ b/src/sorters/execSorts.js
@@ -5,6 +5,8 @@ const { sortBySection } = require('./sortBySection.js');
 /**
  * @description Execute various sorting functions
  * @param ast {[]} The AST with parsed information
+ * @return ats {[]} The AST "sorted" with appropriate headers and priorities
+ * assigned to it.
  */
 
 const execSorts = (ast) => {
@@ -19,14 +21,44 @@ const execSorts = (ast) => {
   return sortBySection(ast, sectionName, priority);
 };
 
+
+/**
+ * @description This will cleanup the incoming AST structure
+ * @param ast {[]} The AST with parsed information
+ * @return commentBlocks {[]} Return an array of commentBlock objects.Each object
+ * will be in the following format as an object:
+ *
+ *                                  {
+ *                                    header: (string or undefined),
+ *                                    priority: (number or undefined),
+ *                                    description: (string),
+ *                                    tags: ([
+ *                                            {
+ *                                              title: (string),
+ *                                              description: (string)
+ *                                            }
+ *                                          ])
+ *                                  }
+ */
+
+const cleanAST = (ast) => {
+  const commentBlocks = [];
+
+  ast.forEach((file) => {
+    file.content.forEach((commentBlock) => {
+      commentBlocks.push({
+        header: undefined,
+        priority: undefined,
+        description: commentBlock.description,
+        tags: commentBlock.tags,
+        name: commentBlock.name,
+        pathName: file.fileName,
+      });
+    });
+  });
+
+  return commentBlocks;
+};
+
 module.exports.execSorts = execSorts;
-
-/* eslint-disable */
-/*
-
-Current Notes:
-  The latest custom tag will overwrite earlier custom tags (like CSS rules),
-  this allows the user to easily reassign
-
-
-*/
+module.exports.cleanAST = cleanAST;

--- a/src/sorters/sortBySection.js
+++ b/src/sorters/sortBySection.js
@@ -39,7 +39,6 @@ const sortBySection = (ast, sectionTag, priority) => {
       });
     });
   });
-  // console.log(JSON.stringify(ast));
   return ast;
 };
 


### PR DESCRIPTION
[1] Added a "cleanAST" function to the execSorts.js file
     The purpose of this function is to iterate through the AST and output in updated format.
     Please see jsDocs documentation for the function to understand more.

[2] Right now this clean AST is not yet being called in the CLI.js, but will update sort methods to import the cleaned AST and process accordingly in the next pull request.