### PR TITLE
Escape backticks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ package-lock.json
 #files
 bundle.js
 *.bundle.js
-outputFromTest.js
+example.js
+example.json

--- a/mockData/arrowExpression.jsx
+++ b/mockData/arrowExpression.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 /* eslint-enable */
 
 /**
- * @description \\\\\\`displays\\\\\` the info about the field
+ * @description displays the info about the field
  * @param props.data.fieldName the name of the field
  * @param props.data.notes the notes on the field
  */

--- a/mockData/arrowExpression.jsx
+++ b/mockData/arrowExpression.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 /* eslint-enable */
 
 /**
- * @description displays the info about the field
+ * @description \\\\\\`displays\\\\\` the info about the field
  * @param props.data.fieldName the name of the field
  * @param props.data.notes the notes on the field
  */

--- a/src/parser/extract.js
+++ b/src/parser/extract.js
@@ -105,7 +105,7 @@ const walk = (searchPath, ROOT) => {
       process.stdout.write('\n');
       if (unReadableFiles.length !== 0) {
         /* eslint-disable-next-line no-console */
-        console.log(`${unReadableFiles.lenth} files were unparsable, and thus ommited from parsing:`);
+        console.log(`${unReadableFiles.length} files were unparsable, and thus ommited from parsing:`);
         /* eslint-disable-next-line no-console */
         unReadableFiles.forEach(fileName => console.log(fileName));
       } else {

--- a/src/parser/parseComments.js
+++ b/src/parser/parseComments.js
@@ -1,25 +1,5 @@
 const doctrine = require('doctrine');
-const fs = require('fs');
-const { parseCommentsTemplate } = require('./utils/webpackTemplates.js');
 const errors = require('./utils/errors.js');
-
-/**
- * @description This function will save the data to the client/dist folder
- * @section Heading1
- * @section Heading2
- */
-
-const saveTags = (data, path) => {
-  // TODO : i think there needs to be another escape handling added here to be
-  // TODOv: able to parse comments that contain backticks
-  const dataToSave = JSON.stringify(data).replace(/\\n/g, '\\\\n');
-  fs.writeFile(path, parseCommentsTemplate(dataToSave), (err) => {
-    if (err) {
-      console.log(err); /* eslint-disable-line no-console */
-    }
-  });
-};
-
 
 const procDesc = (descriptionTagArray, fileObjDesc) => {
   let description = fileObjDesc;
@@ -62,7 +42,7 @@ const processFile = (tagArray) => {
  * @section section name 2
  * @return n/a
  */
-const parseComments = (filesArray, address) => {
+const parseComments = (filesArray) => {
   errors.parseCommentsArrayErr(filesArray);
 
   const files = [];
@@ -72,7 +52,6 @@ const parseComments = (filesArray, address) => {
     fileContent.fileName = file.name;
     files.push(fileContent);
   });
-  saveTags(files, address);
   return files;
 };
 

--- a/src/parser/saveTags.js
+++ b/src/parser/saveTags.js
@@ -3,8 +3,8 @@ const { parseCommentsTemplate } = require('./utils/webpackTemplates.js');
 
 const saveTags = (data, path) => {
   const dataToSave = JSON.stringify(data)
-  .replace(/(?<!\\)(?:\\\\)*\\n/g, '\\\\n`') // replaces \n where there is odd number of \ with a \\n
-  .replace(/(?<!\\)(?:\\\\)*`/g, '\\`'); //  replaces ` and any ` preceded by an odd number of \ with a \`
+    .replace(/(?<!\\)(?:\\\\)*\\n/g, '\\\\n`') // replaces \n where there is odd number of \ with a \\n
+    .replace(/(?<!\\)(?:\\\\)*`/g, '\\`'); //  replaces ` and any ` preceded by an odd number of \ with a \`
   fs.writeFile(path, parseCommentsTemplate(dataToSave), (err) => {
     if (err) {
       console.log(err); /* eslint-disable-line no-console */

--- a/src/parser/saveTags.js
+++ b/src/parser/saveTags.js
@@ -2,7 +2,9 @@ const fs = require('fs');
 const { parseCommentsTemplate } = require('./utils/webpackTemplates.js');
 
 const saveTags = (data, path) => {
-  const dataToSave = JSON.stringify(data).replace(/`/g, '\\`');
+  const dataToSave = JSON.stringify(data)
+  .replace(/(?<!\\)(?:\\\\)*\\n/g, '\\\\n`') // replaces \n where there is odd number of \ with a \\n
+  .replace(/(?<!\\)(?:\\\\)*`/g, '\\`'); //  replaces ` and any ` preceded by an odd number of \ with a \`
   fs.writeFile(path, parseCommentsTemplate(dataToSave), (err) => {
     if (err) {
       console.log(err); /* eslint-disable-line no-console */

--- a/src/parser/saveTags.js
+++ b/src/parser/saveTags.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const { parseCommentsTemplate } = require('./utils/webpackTemplates.js');
 
 const saveTags = (data, path) => {
-  const dataToSave = JSON.stringify(data).replace(/\\n/g, '\\\\n');
+  const dataToSave = JSON.stringify(data).replace(/`/g, '\\`');
   fs.writeFile(path, parseCommentsTemplate(dataToSave), (err) => {
     if (err) {
       console.log(err); /* eslint-disable-line no-console */


### PR DESCRIPTION
fixed a spelling error in the extract file

removed the old save tags function from the parse comments file

added regex to the save tags function to correctly handle \n and backticks inside of comments