### PR TITLE
Clean Data For Front-End

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -123,7 +123,8 @@ yargs.parse(process.argv.slice(2), (err, argv, output) => {
     } else {
       // const exclude = fs.readFileSync(`${pathData.absPath}/.gutenignore`, 'utf8').split('\n');
       extract(['./']).then((data) => {
-        const ast = parseComments(data, address);
+        const rawAST = parseComments(data, address);
+        const ast = cleanAST(rawAST);
         const dataToWrite = execSorts(ast);
         saveTags(dataToWrite, address);
       });

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -161,7 +161,6 @@ yargs.parse(process.argv.slice(2), (err, argv, output) => {
           const rawAST = parseComments(data, address);
           const ast = cleanAST(rawAST);
           const dataToWrite = execSorts(ast);
-          console.log(dataToWrite);
           saveTags(dataToWrite, address);
         });
       }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,7 +15,7 @@ const {
   refreshAPI,
   generateAPIFrame,
 } = require('../src/utils.js');
-const { execSorts } = require('../src/sorters/execSorts.js');
+const { execSorts, cleanAST } = require('../src/sorters/execSorts.js');
 const { saveTags } = require('../src/parser/saveTags.js');
 
 yargs.usage(`$0 ${

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -158,7 +158,8 @@ yargs.parse(process.argv.slice(2), (err, argv, output) => {
       // No invalid file paths supplied.  Parse the files.
       if (missingFiles.length === 0) {
         extract(argv._).then((data) => {
-          const ast = parseComments(data, address);
+          const rawAST = parseComments(data, address);
+          const ast = cleanAST(rawAST);
           const dataToWrite = execSorts(ast);
           saveTags(dataToWrite, address);
         });

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -161,6 +161,7 @@ yargs.parse(process.argv.slice(2), (err, argv, output) => {
           const rawAST = parseComments(data, address);
           const ast = cleanAST(rawAST);
           const dataToWrite = execSorts(ast);
+          console.log(dataToWrite);
           saveTags(dataToWrite, address);
         });
       }

--- a/src/sorters/execSorts.js
+++ b/src/sorters/execSorts.js
@@ -4,12 +4,12 @@ const { sortBySection } = require('./sortBySection.js');
 
 /**
  * @description Execute various sorting functions
- * @param ast {[]} The AST with parsed information
+ * @param commentBlocks {[]} The Cleaned AST with parsed information
  * @return ats {[]} The AST "sorted" with appropriate headers and priorities
  * assigned to it.
  */
 
-const execSorts = (ast) => {
+const execSorts = (commentBlocks) => {
   // extract an array of files to be sorted
   // const sortFiles = gutenrc.skeleton.sortByOrder;
   // console.log(ast);
@@ -18,7 +18,7 @@ const execSorts = (ast) => {
   const gutenRC = JSON.parse(fs.readFileSync(pathData.absPath.concat('.gutenrc.json')));
   const sectionName = gutenRC.skeleton.sortBySections.sections;
   const priority = 1;
-  return sortBySection(ast, sectionName, priority);
+  return sortBySection(commentBlocks, sectionName, priority);
 };
 
 

--- a/src/sorters/execSorts.js
+++ b/src/sorters/execSorts.js
@@ -28,17 +28,12 @@ const execSorts = (commentBlocks) => {
  * @return commentBlocks {[]} Return an array of commentBlock objects.Each object
  * will be in the following format as an object:
  *
- *                                  {
- *                                    header: (string or undefined),
- *                                    priority: (number or undefined),
- *                                    description: (string),
- *                                    tags: ([
- *                                            {
- *                                              title: (string),
- *                                              description: (string)
- *                                            }
- *                                          ])
- *                                  }
+ *  {
+ *   header: (string or undefined),
+ *   priority: (number or undefined),
+ *   description: (string),
+ *   tags: [{title: (string), description: (string)}]
+ *  }
  */
 
 const cleanAST = (ast) => {

--- a/src/sorters/sortBySection.js
+++ b/src/sorters/sortBySection.js
@@ -9,37 +9,41 @@
  */
 
 
-const sortBySection = (ast, sectionTag, priority) => {
-  if (!(ast instanceof Array)) {
-    throw new TypeError('sortBySection Error: Must Receive Parsed Data as an Array');
-  }
+// const sortBySection = (ast, sectionTag, priority) => {
+//   if (!(ast instanceof Array)) {
+//     throw new TypeError('sortBySection Error: Must Receive Parsed Data as an Array');
+//   }
 
-  if ((ast.length === 0)) {
-    throw new TypeError('sortBySection Error: Parsed Data Array Must Contain Values');
-  }
+//   if ((ast.length === 0)) {
+//     throw new TypeError('sortBySection Error: Parsed Data Array Must Contain Values');
+//   }
 
-  // if (!(typeof (sectionTag) !== 'string')) {
-  //   throw new TypeError('sortBySection Error: Section Tag Must Be In String Format');
-  // }
+//   // if (!(typeof (sectionTag) !== 'string')) {
+//   //   throw new TypeError('sortBySection Error: Section Tag Must Be In String Format');
+//   // }
 
-  // if (!(priority instanceof Number)) {
-  //   throw new TypeError('sortBySection Error: priority must be of type "Number"');
-  // }
+//   // if (!(priority instanceof Number)) {
+//   //   throw new TypeError('sortBySection Error: priority must be of type "Number"');
+//   // }
 
-  const sectionName = sectionTag.slice(1);
-  ast.forEach((file) => {
-    file.content.forEach((docBlock) => {
-      docBlock.tags.forEach((tag) => {
-        if (tag.title === sectionName) {
-          /* eslint-disable */
-          docBlock.header = tag.description;
-          docBlock.priority = priority;
-          /* eslint-enable */
-        }
-      });
-    });
-  });
-  return ast;
+//   const sectionName = sectionTag.slice(1);
+//   ast.forEach((file) => {
+//     file.content.forEach((docBlock) => {
+//       docBlock.tags.forEach((tag) => {
+//         if (tag.title === sectionName) {
+//           /* eslint-disable */
+//           docBlock.header = tag.description;
+//           docBlock.priority = priority;
+//           /* eslint-enable */
+//         }
+//       });
+//     });
+//   });
+//   return ast;
+// };
+
+const sortBySection = (commentBlocks, sectionTag, priority) => {
+
 };
 
 module.exports.sortBySection = sortBySection;

--- a/src/sorters/sortBySection.js
+++ b/src/sorters/sortBySection.js
@@ -43,7 +43,22 @@
 // };
 
 const sortBySection = (commentBlocks, sectionTag, priority) => {
+  const sectionName = sectionTag.slice(1);
 
+  commentBlocks.forEach((block) => {
+    if (block.header === undefined && block.priority === undefined) {
+      block.tags.forEach((tag) => {
+        if (tag.title === sectionName) {
+          /* eslint-disable */
+          block.header = sectionName;
+          block.priority = priority;
+          /* eslint-enable */
+        }
+      });
+    }
+  });
+
+  return commentBlocks;
 };
 
 module.exports.sortBySection = sortBySection;


### PR DESCRIPTION
Refactor SortBySection function to work with cleaned data, and export cleaned data.

Refactored CLI for individual file arguments and --all arguments coniditionals to first clean all data before passing data to "sorting" functions.

Front-end should now have data to work with in the correct format as requested earlier.