### PR TITLE
Refactor src/utils.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm install -g gutendocs
 > From within the root directory of the repo you want to generate an API for:
 
 ```sh
-gutendocs --init
+gutendocs init
 ```
 
 > To generate an API from JSDocs of a single .js/.jsx file:
@@ -51,7 +51,7 @@ gutendocs --all
 
 > To restore the API to the original state run this at the same level or subdirectory of init location:
 ```sh
-gutendocs --reset
+gutendocs reset
 ```
 
 > To restore the API to the original state run this at the same level or subdirectory of init location:
@@ -61,7 +61,7 @@ gutendocs --help
 
 > To update API with settings from gutenConfig.json:
 ```sh
-gutendocs --config
+gutendocs config
 ```
 
 > To get latest version information:
@@ -72,7 +72,7 @@ gutendocs --info
 > Customize the theme of the API:
 ```sh
 edit styles.css or the gutenConfig.json and run:
-gutendocs --config
+gutendocs config
 ```
 
 ## Requirements

--- a/client/dist/.gutenRCTemplate.json
+++ b/client/dist/.gutenRCTemplate.json
@@ -8,5 +8,6 @@
     "sortByFileStructure": {
       
     }
-  }
+  },
+  "verbosity": 1
 }

--- a/src/__mocks__/utils.js
+++ b/src/__mocks__/utils.js
@@ -1,3 +1,3 @@
-const findRC = () => ({ absPath: './', dirName: 'GutenApi' });
+const getRC = () => ({ absPath: './', dirName: 'GutenApi' });
 
-module.exports.findRC = findRC;
+module.exports.getRC = getRC;

--- a/src/parser/extract.js
+++ b/src/parser/extract.js
@@ -11,7 +11,7 @@ const path = require('path');
 const {
   Walker,
 } = require('ignore-walk');
-const { findRC } = require('../utils.js');
+const { getRC } = require('../utils.js');
 
 const globParse = address => new Promise((resolve, reject) => glob(address, {
   dot: true,
@@ -117,7 +117,7 @@ const walk = (searchPath, ROOT) => {
 
 
 const extract = arr => Promise.all(arr.map(x => globParse(x))).then((x) => {
-  const ROOT = findRC().absPath;
+  const ROOT = getRC().absPath;
   const paths = [].concat(...x);
   return Promise.all(paths.map(address => walk(address, ROOT)))
     .then(result => [].concat(...result));

--- a/src/sorters/execSorts.js
+++ b/src/sorters/execSorts.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { findRC } = require('../utils.js');
+const { getRC } = require('../utils.js');
 const { sortBySection } = require('./sortBySection.js');
 
 /**
@@ -14,7 +14,7 @@ const execSorts = (commentBlocks) => {
   // const sortFiles = gutenrc.skeleton.sortByOrder;
   // console.log(ast);
   // execute a piping function sequence here
-  const pathData = findRC();
+  const pathData = getRC();
   const gutenRC = JSON.parse(fs.readFileSync(pathData.absPath.concat('.gutenrc.json')));
   const sectionName = gutenRC.skeleton.sortBySections.sections;
   const priority = 1;

--- a/src/utils.js
+++ b/src/utils.js
@@ -132,7 +132,7 @@ const getRC = () => {
       return false;
     }
     if (gutenfolder === undefined) {
-      throw new Error('Your gutenrc folder seems to be missing a apiDir key indicating where the folder should be. Either add a key of apiDir with a value of the name of your api folder or delete the RC file and reinitialize.  WARNING!!!!! This will erase any work you have done in the folder.');
+      throw new Error('Your gutenrc folder seems to be missing a apiDir key indicating where the folder should be. Either add a key of apiDir with a value of the name of your api folder or delete the RC file and reinitialize.  A backup of your Api Folder will be created as [folderName].backup#.');
     }
     const RCTemplatePath = path.dirname(__dirname).concat('/client/dist/.gutenRCTemplate.json');
     return fillBlanksWithDefaults(RCTemplatePath, gutenrc);
@@ -182,7 +182,12 @@ const generateFilesaveArray = (destination, dirName) => {
   ));
 
   const APIdir = destination.concat(dirName);
-  if (!fs.existsSync(APIdir)) fs.mkdirSync(APIdir);
+  if (fs.existsSync(APIdir)) {
+    const BackupDirName = findValidBackupName(destination, dirName);
+    fs.renameSync(APIdir, BackupDirName);
+  }
+
+  fs.mkdirSync(APIdir);
 
   const imgDir = APIdir.concat('imgs/');
   if (!fs.existsSync(imgDir)) fs.mkdirSync(imgDir);
@@ -202,7 +207,7 @@ const updateConfig = (gutenrc) => {
     throw new Error('Write Error:'
     + 'The folder specified in the .gutenrc.json file seems to be missing.'
     + 'Update .gutenrc.json to match your API folder if you have changed the folder name,'
-    + 'or call "gutendocs --reset" if and only if you have accidentally deleted it'
+    + 'or call "gutendocs reset" if and only if you have accidentally deleted it'
     + 'and would like it to be reset to the original state.');
   } else {
     let configSettings = fs.readFileSync(pathToConfigJSON);

--- a/src/utils.js
+++ b/src/utils.js
@@ -149,7 +149,7 @@ const getRC = () => {
  * @return { boolean } indicates whether or not this is a file of interest
  */
 const filterFiles = (file, dirPath, toIgnore) => {
-  const fieslToIgnore = toIgnore || ['.DS_Store'];
+  const fieslToIgnore = toIgnore || ['.DS_Store', '.gutenRCTemplate.json'];
   if (fieslToIgnore.includes(file)) return false;
   if (fs.lstatSync(dirPath.concat(file)).isDirectory()) return false;
   return true;

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,7 +13,7 @@ const inquirerOptions = require('./inquirerOptions.js');
 
 const fillBlanksWithDefaults = (defaultSettingsPath, assignedSettings) => {
   const defaultConfig = fs.readFileSync(defaultSettingsPath);
-  const mergedSettings = Object.assign(JSON.parse(assignedSettings), JSON.parse(defaultConfig));
+  const mergedSettings = Object.assign(JSON.parse(defaultConfig), JSON.parse(assignedSettings));
   return mergedSettings;
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -183,8 +183,8 @@ const generateFilesaveArray = (destination, dirName) => {
 
   const APIdir = destination.concat(dirName);
   if (fs.existsSync(APIdir)) {
-    const BackupDirName = findValidBackupName(destination, dirName);
-    fs.renameSync(APIdir, BackupDirName);
+    const BackupDirName = findValidBackupName(path.dirname(destination), dirName);
+    fs.renameSync(APIdir, destination.concat(BackupDirName));
   }
 
   fs.mkdirSync(APIdir);


### PR DESCRIPTION
added JSDoc comments to all functions in utils

refactored all console logs into errors

refactored findRC into getRC which now returns the entire RC settings object

refactored getRC to set default settings for anything a user may have deleted from their RC file

refactored generatefilearray to ignore .ds_store files as well as read all files rather than specific ones

refactored cli to catch all errors and present messages differently depending on the verbosity

refactored SOME of the readme to reflect some of the changes to the cli usage

refactored reset to create a backup of the api folder incase the user wants to have access to previous progress

added verbosity to the gutenRC file