### PR TITLE
now only reset --backup will create a backup folder

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -49,13 +49,19 @@ yargs.command(['init [file]', 'i'], 'initialize gutendocs', {}, (argv) => {
   generateAPIFrame('./', argv.file || 'GutenApi/');
 });
 
-yargs.command(['reset', 'r'], 'overwrite api folder with initial values', {},
-  () => {
-    const gutenrc = getRC();
-    if (gutenrc) {
-      refreshAPI(gutenrc);
-    }
-  });
+yargs.command(['reset', 'r'], 'overwrite api folder with initial values', {
+  backup: {
+    alias: 'b',
+    describe: 'create a backup copy before resetting the folder',
+  },
+},
+(argv) => {
+  const gutenrc = getRC();
+  if (gutenrc) {
+    refreshAPI(gutenrc, argv.backup);
+  }
+});
+
 yargs.command(['parse', 'document', 'doc', 'd'], 'Parse all file in dir and subdir', {
   all: {
     alias: 'a',

--- a/src/utils.js
+++ b/src/utils.js
@@ -159,8 +159,9 @@ const filterFiles = (file, dirPath, toIgnore) => {
  * by copying them from the gutendocs client folder
  * @param { string } destination the path to the directory the API folder should be made in
  * @param { string } dirName the name of the folder the API dir should have
+ * @param { boolean } backup whether or not to make a backup folder
  */
-const generateFilesaveArray = (destination, dirName) => {
+const generateFilesaveArray = (destination, dirName, backup) => {
   const filesToWrite = [];
   const srcPath = path.dirname(__dirname).concat('/client/dist/');
   const srcFiles = fs.readdirSync(srcPath).filter(file => filterFiles(file, srcPath));
@@ -181,12 +182,12 @@ const generateFilesaveArray = (destination, dirName) => {
   ));
 
   const APIdir = destination.concat(dirName);
-  if (fs.existsSync(APIdir)) {
+  if (fs.existsSync(APIdir) && backup) {
     const BackupDirName = findValidBackupName(destination, dirName);
     fs.renameSync(APIdir, destination.concat(BackupDirName));
+    fs.mkdirSync(APIdir);
   }
 
-  fs.mkdirSync(APIdir);
 
   const imgDir = APIdir.concat('imgs/');
   if (!fs.existsSync(imgDir)) fs.mkdirSync(imgDir);
@@ -237,9 +238,10 @@ const updateConfig = (gutenrc) => {
 /**
  * refreshes the API with all the settings to the defauts
  * @param { {} } gutenrc the gutenrc object the defines the users settings
+ * @param { boolean } backup whether or not to make a backup folder
  */
-const refreshAPI = (gutenrc) => {
-  generateFilesaveArray(gutenrc.absPath, gutenrc.apiDir);
+const refreshAPI = (gutenrc, backup) => {
+  generateFilesaveArray(gutenrc.absPath, gutenrc.apiDir, backup);
   updateConfig(gutenrc);
 };
 


### PR DESCRIPTION
now when you run "gutendocs reset" it will not create a backup folder, but now if you call "gutendocs reset --backup" it will create a backup of the folder before overwriting any work in progress.