### PR TITLE
Fix sorter comments

### DIFF
--- a/src/sorters/execSorts.js
+++ b/src/sorters/execSorts.js
@@ -1,18 +1,16 @@
-const fs = require('fs');
 const R = require('ramda');
 const { getRC } = require('../utils.js');
 const { ...sortFxnsObj } = require('./sorters.js');
 
 /**
  * @description Execute various sorting functions
- * @param ast {[]} The Cleaned AST with parsed information
- * @return ast {[]} The AST "sorted" with appropriate headers and priorities
+ * @param {[]} ast The Cleaned with parsed information
+ * @return {[]} ast The AST "sorted" with appropriate headers and priorities
  * assigned to it.
  */
 
 const execSorts = (ast) => {
-  const pathData = getRC();
-  const gutenRC = JSON.parse(fs.readFileSync(pathData.absPath.concat('/.gutenrc.json')));
+  const gutenRC = getRC();
   // options will contain sorting options for particular functions.  In this case: sectionSort
   const options = {
     sectionTag: gutenRC.skeleton.sortBySection.section,
@@ -28,10 +26,9 @@ const execSorts = (ast) => {
 
 /**
  * @description This will cleanup the incoming AST structure
- * @param ast {[]} The AST with parsed information
- * @return commentBlocks {[]} Return an array of commentBlock objects.Each object
- * will be in the following format as an object:
- *
+ * @param {[]} ast The AST with parsed information
+ * @return {[]} commentBlocks Return an array of commentBlock objects.
+ * @example return
  *  {
  *   header: (string or undefined),
  *   priority: (number or undefined),

--- a/src/sorters/execSorts.js
+++ b/src/sorters/execSorts.js
@@ -4,7 +4,7 @@ const { ...sortFxnsObj } = require('./sorters.js');
 
 /**
  * @description Execute various sorting functions
- * @param {[]} ast The Cleaned with parsed information
+ * @param {[]} ast The Cleaned AST with parsed information
  * @return {[]} ast The AST "sorted" with appropriate headers and priorities
  * assigned to it.
  */

--- a/src/sorters/sorters.js
+++ b/src/sorters/sorters.js
@@ -2,8 +2,8 @@
  * @description A function that will assign the classification headings based upon
  * whether or not end-user has specified a custom tag.  catchAllSection is option
  * see params below.
- * @param data {[]} Receive [ast-array, priority-number, options-object]
- * @return updatedData {[]} [ast-array, priority-number, options-object]
+ * @param {[]} data Receive [ast-array, priority-number, options-object]
+ * @return {[]} updatedData [ast-array, priority-number, options-object]
  */
 const sortBySection = (data) => {
   const commentBlocks = data[0];
@@ -29,7 +29,7 @@ const sortBySection = (data) => {
   * @description A function that will assign a general header name to unclassified
   * comment blocks
   * @param {[]} data Receive [ast-array, priority-number, options-object]
-  * @return ast {[]} Return the AST formatted to have priority and headers according to sections
+  * @return {[]} ast Return the AST formatted to have priority and headers according to sections
   */
 const catchAll = (data) => {
   const commentBlocks = data[0];
@@ -53,7 +53,7 @@ const catchAll = (data) => {
 /**
   * @description A function that will assign a general header name based on fileName
   * @param {[]} data Receive [ast-array, priority-number, options-object]
-  * @return ast {[]} Return the AST formatted to have priority and headers according to sections
+  * @return {[]} ast Return the AST formatted to have priority and headers according to sections
   */
 const sortByFileName = (data) => {
   /* Function implementation goes here */


### PR DESCRIPTION
there was a redundant use of getRC when the values of get rc were used to fs.read gutenrc again

I think I told uday to do this, but it was unneeded as you already had the file you were trying to read in

fixed comments to have the correct JSDoc format