### PR TITLE
added the basics to guten ignore

### DIFF
--- a/.gutenignore
+++ b/.gutenignore
@@ -1,1 +1,7 @@
 node_modules
+.*
+GutenApi
+__tests__
+__mocks__
+*.bundle.js
+bundle.js


### PR DESCRIPTION
I feel like we should all have these in our guten ignore as it was searching hidden folders like .git and other things making the list of files it failed to parse uninteresting.  But now that I have added them it seems the parser needs some work as it is unable to parse pretty much any file with important stuff in it:

The following 5 files were unparsable
***********
GutenDocs/bin/cli.js
GutenDocs/client/src/components/App.jsx
GutenDocs/src/parser/saveTags.js
GutenDocs/src/sorters/execSorts.js
GutenDocs/src/utils.js