### PR TITLE
moved the acorn settings for parsing into gutenrc

### DIFF
--- a/client/dist/.gutenRCTemplate.json
+++ b/client/dist/.gutenRCTemplate.json
@@ -18,5 +18,9 @@
       "section": "Miscellaneous"
     }
   },
+  "acornSettings": {
+    "allowImportExportEverywhere": true,
+    "allowHashBang": true
+  },
   "verbosity": 1
 }

--- a/src/__mocks__/utils.js
+++ b/src/__mocks__/utils.js
@@ -1,3 +1,5 @@
-const getRC = () => ({ absPath: './', dirName: 'GutenApi' });
+const templateRC = require('../../client/dist/.gutenRCTemplate.json');
+
+const getRC = () => Object.assign({ absPath: './' }, templateRC);
 
 module.exports.getRC = getRC;

--- a/src/parser/extract.js
+++ b/src/parser/extract.js
@@ -31,12 +31,12 @@ const exclude = (arr) => {
   });
 };
 
-const acornParse = (content, tagContent) => {
+const acornParse = (content, tagContent, gutenrc) => {
   parse(content, {
     plugins: {
       jsx: true,
     },
-    allowImportExportEverywhere: true,
+    ...gutenrc.acornSettings,
     onComment: (b, t, s, d) => {
       if (b && t[0] === '*') {
         const a = {
@@ -66,7 +66,7 @@ const extract = arr => exclude(arr).then((list) => {
     };
     const content = fs.readFileSync(`${path.dirname(gutenrc.absPath)}/${file}`, 'utf8');
     try {
-      acornParse(content, tag.content);
+      acornParse(content, tag.content, gutenrc);
     } catch (e) {
       badFiles.push(file);
       if (gutenrc.verbosity >= 4) {


### PR DESCRIPTION
I just thought of this a minute ago, I think this is a good way to allow people to control the acorn settings from the gutenrc file so that if someone knows acorn well they can improve the tool without changing code.