### PR TITLE
made it so setting verbosity only updates the 1 setting

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -286,15 +286,14 @@ const generateAPIFrame = (relPath, apiDir) => {
 const setVerbosity = (level, gutenrc, globally) => {
   if (typeof level === 'number' && level >= 0 && level <= 5) {
     if (gutenrc) {
-      let newSettings = Object.assign({}, gutenrc);
+      let newSettings = JSON.parse(fs.readFileSync(gutenrc.absPath.concat('.gutenrc.json')));
       newSettings.verbosity = level;
-      delete newSettings.absPath;
       newSettings = JSON.stringify(newSettings, null, 2);
       fs.writeFileSync(gutenrc.absPath.concat('.gutenrc.json'), newSettings);
     }
     if (globally) {
       const pathToGlobal = path.dirname(__dirname).concat('/client/dist/.gutenRCTemplate.json');
-      let globalSettings = Object.assign({}, JSON.parse(fs.readFileSync(pathToGlobal)));
+      let globalSettings = JSON.parse(fs.readFileSync(pathToGlobal));
       globalSettings.verbosity = level;
       delete globalSettings.absPath;
       globalSettings = JSON.stringify(globalSettings, null, 2);


### PR DESCRIPTION
before it was overwriting everything in the folder including settings a user may have removed

now if the gutenrc is empty the only thing the verbosity command will do is set verbosity.

This is acheived by reading the rc file with fs.readFile instead of getRC which would add the defaults into whatever it returns.  It then modifies the verbosity and resaves it.  