### PR TITLE
Create guten ignore

### DIFF
--- a/.gutenignore
+++ b/.gutenignore
@@ -1,6 +1,11 @@
+#ignore your dependancies
 node_modules
+#ignore hidden folders like .git
 .*
-GutenApi
+#ignore your generated API folder
+GutenApi/
+
+#additional folders and files to ignore
 __tests__
 __mocks__
 *.bundle.js

--- a/.gutenignore
+++ b/.gutenignore
@@ -8,6 +8,5 @@ GutenApi/
 #additional folders and files to ignore
 __tests__
 __mocks__
-*.bundle.js
-bundle.js
+bundles.js
 mockData

--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -1,30 +1,29 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="utf-8" />
-    <title>GutenDocs</title>
-    <!-- <meta name="viewport" content="width=device-width, initial-scale=1"> -->
-    <link rel="stylesheet" type="text/css" href="styles.css" />
-    <link 
-      rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
-    >
-
+  <meta charset="utf-8" />
+  <title>GutenDocs</title>
+  <!-- <meta name="viewport" content="width=device-width, initial-scale=1"> -->
+  <link rel="stylesheet" type="text/css" href="styles.css" />
+  <link 
+    rel="stylesheet" 
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
+  >
 </head>
 <body>
-    <div id="app"></div>
-    <script type="text/javascript" src="./gutenConfig.js"></script>
-    <script type="text/javascript" src="./parsedData.js"></script>
-    <script type="text/javascript" src="./bundle.js"></script>
-
-    <a href="https://github.com/GutenTech/GutenDocs">
-        <img
-          style="position: absolute; top: 0; right: 0;border: 0;"
-          src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"
-          alt="Fork me on GitHub">
-    </a>
-
+  <div id="app"></div>
+  <script type="text/javascript" src="./gutenConfig.js"></script>
+  <script type="text/javascript" src="./parsedData.js"></script>
+  <script type="text/javascript" src="./bundle.js"></script>
+  <a href="https://github.com/GutenTech/GutenDocs">
+    <img
+      style="position: absolute; top: 0; right: 0;border: 0;"
+      src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"
+      alt="Fork me on GitHub"
+    >
+  </a>
 </body>
   <div id="footer">
-      &copy; All rights reserved by GutenTech 2018
+    &copy; All rights reserved by GutenTech 2018
   </div>
 </html>

--- a/src/parser/saveTags.js
+++ b/src/parser/saveTags.js
@@ -17,7 +17,7 @@ const saveTags = (data, writePath) => {
     + `\n\nwindow.${variableName} = ${variableName};`,
     (err) => {
       if (err) {
-        console.log(err); /* eslint-disable-line no-console */
+        throw err;
       }
     });
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -203,7 +203,7 @@ const refreshAPI = (gutenrc, backup) => {
 /**
  * Generates a API folder as well as a gutenRC file
  * @param { string } relPath the directory that the user wants to make the APIDir
- * @param { string } dirName the desired name of the APIDir
+ * @param { string } apiDir the desired name of the APIDir
  */
 const generateAPIFrame = (relPath, apiDir) => {
   const srcPath = path.dirname(__dirname).concat('/');
@@ -215,6 +215,17 @@ const generateAPIFrame = (relPath, apiDir) => {
       apiDir,
     });
     fs.writeFileSync(absPath.concat('.gutenrc.json'), JSON.stringify(mergedRC, null, 2));
+
+    const gutenIgnoreContents = '#ignore your dependancies\n'
+    + 'node_modules\n'
+    + '#ignore hidden folders like .git\n'
+    + '.*\n'
+    + '#ignore your generated API folder\n'
+    + `${apiDir}\n\n`
+    + '#additional folders and files to ignore\n';
+    if (!fs.existsSync(relPath.concat('.gutenignore'))) {
+      fs.writeFileSync(relPath.concat('.gutenignore'), gutenIgnoreContents);
+    }
   } else {
     throw Error('You have already initialized gutendocs in this Repo.  If you want to refresh the files call "gutendocs --reset"');
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -201,7 +201,7 @@ const refreshAPI = (gutenrc, backup) => {
 };
 
 /**
- * adds .gutenignore to the ignore language is vscodes autodetect language settings
+ * adds .gutenignore to the ignore language in vscodes autodetect language settings
  * only implimented for vscode
  * @param { string } absPath path to the root directory gutendocs is being created in
  */

--- a/src/utils.js
+++ b/src/utils.js
@@ -202,6 +202,8 @@ const refreshAPI = (gutenrc, backup) => {
 
 /**
  * adds .gutenignore to the ignore language is vscodes autodetect language settings
+ * only implimented for vscode
+ * @param { string } absPath path to the root directory gutendocs is being created in
  */
 const addIgnoreToLangSettings = (absPath) => {
   const vscodePath = absPath.concat('.vscode/');

--- a/src/utils.js
+++ b/src/utils.js
@@ -201,6 +201,29 @@ const refreshAPI = (gutenrc, backup) => {
 };
 
 /**
+ * adds .gutenignore to the ignore language is vscodes autodetect language settings
+ */
+const addIgnoreToLangSettings = (absPath) => {
+  const vscodePath = absPath.concat('.vscode/');
+  if (fs.existsSync(vscodePath)) {
+    const gutenignoreLangSetting = { 'files.associations': { '.gutenignore': 'ignore' } };
+    let currentSettings = {};
+    let readErr = false;
+    if (fs.existsSync(vscodePath.concat('settings.json'))) {
+      try {
+        currentSettings = JSON.parse(fs.readFileSync(vscodePath.concat('settings.json')));
+      } catch (err) {
+        readErr = err;
+      }
+    }
+    if (!readErr) {
+      const newSettings = Object.assign(currentSettings, gutenignoreLangSetting);
+      fs.writeFileSync(vscodePath.concat('settings.json'), JSON.stringify(newSettings, null, 2));
+    }
+  }
+};
+
+/**
  * Generates a API folder as well as a gutenRC file
  * @param { string } relPath the directory that the user wants to make the APIDir
  * @param { string } apiDir the desired name of the APIDir
@@ -226,6 +249,7 @@ const generateAPIFrame = (relPath, apiDir) => {
     if (!fs.existsSync(relPath.concat('.gutenignore'))) {
       fs.writeFileSync(relPath.concat('.gutenignore'), gutenIgnoreContents);
     }
+    addIgnoreToLangSettings(absPath);
   } else {
     throw Error('You have already initialized gutendocs in this Repo.  If you want to refresh the files call "gutendocs --reset"');
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -248,8 +248,8 @@ const generateAPIFrame = (relPath, apiDir) => {
     + '#ignore your generated API folder\n'
     + `${apiDir}\n\n`
     + '#additional folders and files to ignore\n';
-    if (!fs.existsSync(relPath.concat('.gutenignore'))) {
-      fs.writeFileSync(relPath.concat('.gutenignore'), gutenIgnoreContents);
+    if (!fs.existsSync(absPath.concat('.gutenignore'))) {
+      fs.writeFileSync(absPath.concat('.gutenignore'), gutenIgnoreContents);
     }
     addIgnoreToLangSettings(absPath);
   } else {


### PR DESCRIPTION
creates a gutenignore with default values of node_modules, .* (which ignores hidden folders like .git) and the folder your API is being saved to

also cleaned up index.html (just spacing issues)

and changed a console log I came across to a throw error (in save tags)

also it adds .gutenignore to the vscode workspace settings so that vs code knows autodetect should use the ignore language parser to color the text