### PR TITLE
Customize colors

### DIFF
--- a/.gutenignore
+++ b/.gutenignore
@@ -8,5 +8,5 @@ GutenApi/
 #additional folders and files to ignore
 __tests__
 __mocks__
-bundles.js
+bundle.js
 mockData

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ introTxt: { // for every key in this object 1 section with be rendered with the 
   heading4: 'paragraph4 Lorem ipsum dolor sit amet, consectetur adipiscing elit',
 },
 ```
+##### Using themes
+At GutenTech we know style is important.  We have set up some default themes that you can quickly use to adjust the way your API is rendered.  You can see a list of the themes and there descriptions with `gutendocs theme --list` or `gutendocs theme -l`.  You can then set the theme of your choice by calling `gutendocs theme [themeName]`. You can add custom themes in the API theme folder following the existing structure to add your own.
 
 #### Setting up your .gutenignore
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,6 +13,8 @@ const {
   refreshAPI,
   generateAPIFrame,
   setVerbosity,
+  setTheme,
+  listThemes,
 } = require('../src/utils.js');
 const {
   execSorts,
@@ -98,6 +100,20 @@ yargs.command(['verbosity [level]', 'verbose [level]'], 'Set verbosity level [0-
   if (gutenrc) {
     setVerbosity(argv.level, gutenrc);
   }
+});
+
+yargs.command(['theme [themeName]'], 'Load Themes', {
+  list: {
+    alias: 'l',
+    describe: 'get a list of available themes',
+  },
+}, (argv) => {
+  const gutenrc = getRC();
+  if (Object.prototype.hasOwnProperty.call(argv, 'list')) { // needed hasOwnProperty because 0 is falsy
+    listThemes(gutenrc);
+    return;
+  }
+  setTheme(gutenrc, argv.themeName);
 });
 
 yargs.command(['info'], 'Get info about the package', {},

--- a/client/dist/Themes/bada55.json
+++ b/client/dist/Themes/bada55.json
@@ -5,6 +5,6 @@
     "primaryColorTwo": "#c6e26c",
     "primaryColorThree": "#dbf58a",
     "primaryColorFour": "#b1e216",
-    "primaryColorFive": "badda55"
+    "primaryColorFive": "#badda55"
   }
 }

--- a/client/dist/Themes/bada55.json
+++ b/client/dist/Themes/bada55.json
@@ -1,0 +1,10 @@
+{
+  "description": "A theme based on #bada55",
+  "colors": {
+    "primaryColorOne": "#bada55",
+    "primaryColorTwo": "#c6e26c",
+    "primaryColorThree": "#dbf58a",
+    "primaryColorFour": "#b1e216",
+    "primaryColorFive": "badda55"
+  }
+}

--- a/client/dist/Themes/default.json
+++ b/client/dist/Themes/default.json
@@ -1,0 +1,10 @@
+{
+  "description": "The default theme",
+  "colors": {
+    "primaryColorOne": null,
+    "primaryColorTwo": null,
+    "primaryColorThree": null,
+    "primaryColorFour": null,
+    "primaryColorFive": null
+  }
+}

--- a/client/dist/gutenConfig.js
+++ b/client/dist/gutenConfig.js
@@ -5,6 +5,15 @@ const configData = {
     height: '185',
     width: '175',
   },
+  projectName: 'Gutendocs',
+  colors: {
+    primaryColorOne: false,
+    primaryColorTwo: false,
+    primaryColorThree: false,
+    primaryColorFour: false,
+    primaryColorFive: false,
+  },
+  showGitForkRibbon: true,
   anchorHashJump: 10,
   introTxt: {
     gettingStarted: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
@@ -14,5 +23,8 @@ const configData = {
     FAQ: 'On the other hand, we denounce with righteous indignation and dislike men who are so beguiled and demoralized by the charms of pleasure of the moment, so blinded by desire, that they cannot foresee the pain and trouble that are bound to ensue; and equal blame belongs to those who fail in their duty through weakness of will, which is the same as saying through shrinking from toil and pain. These cases are perfectly simple and easy to distinguish. In a free hour, when our power of choice is untrammelled and when nothing prevents our being able to do what we like best, every pleasure is to be welcomed and every pain avoided. But in certain circumstances and owing to the claims of duty or the obligations of business it will frequently occur that pleasures have to be repudiated and annoyances accepted. The wise man therefore always holds in these matters to this principle of selection: he rejects pleasures to secure other greater pleasures, or else he endures pains to avoid worse pains.',
   },
 };
-
-window.configData = configData;
+try {
+  window.configData = configData;
+} catch (error) {
+  module.exports = configData;
+}

--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>GutenDocs</title>
   <!-- <meta name="viewport" content="width=device-width, initial-scale=1"> -->
   <link rel="stylesheet" type="text/css" href="styles.css" />
   <link 
@@ -15,13 +14,6 @@
   <script type="text/javascript" src="./gutenConfig.js"></script>
   <script type="text/javascript" src="./parsedData.js"></script>
   <script type="text/javascript" src="./bundle.js"></script>
-  <a href="https://github.com/GutenTech/GutenDocs">
-    <img
-      style="position: absolute; top: 0; right: 0;border: 0;"
-      src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"
-      alt="Fork me on GitHub"
-    >
-  </a>
 </body>
   <div id="footer">
     &copy; All rights reserved by GutenTech 2018

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import Intro from './Intro';
 import SideBar from './SideBar';
+import Ribbon from './Ribbon';
 import BodyFunctionDesc from './BodyFunctionDesc';
 import '../../dist/styles.css';
 
@@ -29,11 +30,16 @@ export default class App extends Component {
     };
   }
 
+  componentDidMount() {
+    document.title = window.configData.projectName;
+  }
+
   render() {
-    if (window.parsedData === undefined || window.parsedData.length === 0) {
+    const { parsedData, configData } = window;
+    if (parsedData === undefined || parsedData.length === 0) {
       return (<div>{'Problem Loading Data, did you run "gutendocs parse [<filename>, --all]"'}</div>);
     }
-    if (window.configData === undefined || window.configData === 0) {
+    if (configData === undefined || configData === 0) {
       return (
         <div>
           {'Problem Loading Configuration Data, make sure your gutenConfig is exporting a valid json.'}
@@ -44,22 +50,25 @@ export default class App extends Component {
     const prioritySortedUniqueHeaders = uniqueHeaders(parsedData);
     return (
       <div className="App">
+        <Ribbon show={configData.showGitForkRibbon} />
         <h1 className="logo">
           {/* eslint-disable-next-line jsx-a11y/alt-text */}
-          <img {...window.configData.banner} style={window.configData.banner ? {} : { display: 'none' }} />
+          <img {...configData.banner} style={configData.banner ? {} : { display: 'none' }} />
         </h1>
         <div className="headerlogo">
           <h1 id="gutendocs" data="GutenDocs">
-          GutenDocs
+            {
+              configData.projectName
+            }
           </h1>
         </div>
         <SideBar
-          parsedData={window.parsedData}
+          parsedData={parsedData}
           sortedHeaders={prioritySortedUniqueHeaders}
-          configData={window.configData}
+          configData={configData}
         />
         <div className="starter">
-          <Intro text={window.configData.introTxt} />
+          <Intro text={configData.introTxt} />
         </div>
         {
           prioritySortedUniqueHeaders.map((header, index) => (
@@ -67,9 +76,13 @@ export default class App extends Component {
               <h2 className="body" id={header}>
                 {header}
               </h2>
-              {filterByHeaders(header, window.parsedData)
+              {filterByHeaders(header, parsedData)
                 .map(funcComment => (
-                  <BodyFunctionDesc funcComment={funcComment} key={funcComment.id} />
+                  <BodyFunctionDesc
+                    funcComment={funcComment}
+                    configData={configData}
+                    key={funcComment.id}
+                  />
                 ))
               }
             </div>

--- a/client/src/components/BodyFunctionDesc.jsx
+++ b/client/src/components/BodyFunctionDesc.jsx
@@ -8,12 +8,18 @@ import TagReturn from './TagReturn';
 import TagExample from './TagExample';
 import GeneratedFunc from './GeneratedFunc';
 
-const BodyFunctionDesc = ({ funcComment }) => {
+const BodyFunctionDesc = ({ funcComment, configData }) => {
   const getByTag = (tags, targetTag) => tags
     .filter(tag => (tag.title === targetTag));
   return (
     <div className="bodyTags" key={funcComment.id}>
-      <h5 className="functionName" id={funcComment.name.concat(funcComment.id)}>
+      <h5
+        className="functionName"
+        id={funcComment.name.concat(funcComment.id)}
+        style={configData.colors.primaryColorFour
+          ? { background: configData.colors.primaryColorFour }
+          : {}}
+      >
         {`${funcComment.name}`}
         <GeneratedFunc funcComment={funcComment} />
       </h5>
@@ -36,4 +42,6 @@ export default BodyFunctionDesc;
 BodyFunctionDesc.propTypes = {
   /* eslint-disable-next-line */
   funcComment: PropTypes.object.isRequired,
+  /* eslint-disable-next-line */
+  configData: PropTypes.object.isRequired,
 };

--- a/client/src/components/Ribbon.jsx
+++ b/client/src/components/Ribbon.jsx
@@ -1,0 +1,31 @@
+/* eslint-disable-next-line import/no-extraneous-dependencies */
+import React from 'react';
+/* eslint-disable-next-line import/no-extraneous-dependencies */
+import PropTypes from 'prop-types';
+
+const Ribbon = ({ show }) => (
+  <a href="https://github.com/GutenTech/GutenDocs" style={show ? {} : { display: 'none' }}>
+    <img
+      style={
+          {
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            border: 0,
+          }
+        }
+      src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"
+      alt="Made with Gutendocs"
+    />
+  </a>
+);
+
+export default Ribbon;
+
+Ribbon.propTypes = {
+  show: PropTypes.bool,
+};
+
+Ribbon.defaultProps = {
+  show: true,
+};

--- a/client/src/components/SideBar.jsx
+++ b/client/src/components/SideBar.jsx
@@ -28,9 +28,29 @@ class SideBar extends React.Component {
     const { parsedData } = this.state;
     return (
       <div className="wrapper">
-        <nav id="sidebar">
-          <div id="header">
-            <h5>GutenDocs</h5>
+        <nav
+          id="sidebar"
+          style={configData.colors.primaryColorOne
+            ? {
+              background:
+                'linear-gradient(142deg, '
+                + `${configData.colors.primaryColorTwo}, `
+                + `${configData.colors.primaryColorThree}) `,
+            }
+            : {}
+          }
+        >
+          <div
+            id="header"
+            style={configData.colors.primaryColorOne
+              ? { background: configData.colors.primaryColorOne }
+              : {}}
+          >
+            <h5>
+              {
+                configData.projectName
+              }
+            </h5>
             <br />
           </div>
           <input

--- a/src/utils.js
+++ b/src/utils.js
@@ -186,12 +186,22 @@ const generateFilesaveArray = (destination, dirName, backup) => {
     },
   ));
 
+  const themePath = srcPath.concat('Themes/');
+  const themes = fs.readdirSync(themePath).filter(theme => filterFiles(theme, themePath));
+  themes.forEach(theme => filesToWrite.push(
+    {
+      content: fs.readFileSync(themePath.concat(theme)),
+      writePath: 'Themes/'.concat(theme),
+    },
+  ));
+
   const APIdir = destination.concat(dirName);
   if (fs.existsSync(APIdir) && backup) {
     const BackupDirName = findValidBackupName(destination, dirName);
     fs.renameSync(APIdir, destination.concat(BackupDirName));
     fs.mkdirSync(APIdir);
   }
+
   if (!fs.existsSync(APIdir)) {
     fs.mkdirSync(APIdir);
   }
@@ -201,6 +211,9 @@ const generateFilesaveArray = (destination, dirName, backup) => {
 
   const imgDir = APIdir.concat('imgs/');
   if (!fs.existsSync(imgDir)) fs.mkdirSync(imgDir);
+
+  const themeDir = APIdir.concat('Themes/');
+  if (!fs.existsSync(themeDir)) fs.mkdirSync(themeDir);
 
   filesToWrite.forEach(file => fs.writeFileSync(APIdir.concat(file.writePath), file.content));
 };
@@ -298,6 +311,56 @@ const setVerbosity = (level, gutenrc, globally) => {
   throw new Error('Verbosity level must be a number from 0 to 5');
 };
 
+/**
+ * Console.logs all the themes available.  If verbosity is above 3 also lists contents of theme
+ * @param { object } gutenrc gutenrc settings file
+ */
+const listThemes = (gutenrc) => {
+  const themeFolderPath = gutenrc.absPath.concat(gutenrc.apiDir).concat('Themes/');
+  const themes = fs.readdirSync(themeFolderPath).filter(file => path.extname(file) === '.json');
+  themes.forEach((themeName) => {
+    const theme = JSON.parse(fs.readFileSync(themeFolderPath.concat(themeName)));
+    process.stdout.write(`${path.basename(themeName, '.json')}:`);
+    process.stdout.cursorTo(10);
+    process.stdout.write(`${theme.description}\n`);
+    delete theme.description;
+    if (gutenrc.verbosity >= 3) {
+      /* eslint-disable-next-line no-console */
+      console.log(theme);
+    }
+  });
+};
+
+/**
+ * Create the a string format of the config file with the passed
+ * in object as the export value of configData
+ * @param { object } newConfig a JON formatted object containing the theme adjusted settings
+ */
+const addConfigTemplate = newConfig => '/* eslint-disable quote-props */\n'
+  + '/* eslint-disable quotes */\n'
+  + '/* eslint-disable comma-dangle */\n'
+  + 'const configData = '
+  + `${newConfig}`
+  + ';\ntry {\n  window.configData = configData;\n} catch (error) {\n  module.exports = configData;\n}';
+
+/**
+ * Sets the configfile to the desired theme
+ * @param { object } gutenrc the gutenrc settings
+ * @param { string } themeName the name of the theme you want to set
+ */
+const setTheme = (gutenrc, themeName) => {
+  const pathToGutenConfig = gutenrc.absPath.concat(gutenrc.apiDir).concat('gutenConfig.js');
+  /* eslint-disable-next-line */
+  const configData = require(pathToGutenConfig);
+  const pathToTheme = gutenrc.absPath.concat(`${gutenrc.apiDir}Themes/${themeName}.json`);
+  const themeToLoad = JSON.parse(fs.readFileSync(pathToTheme));
+  delete themeToLoad.description;
+  const newConfig = JSON.stringify(Object.assign(configData, themeToLoad), null, 2);
+  fs.writeFileSync(pathToGutenConfig, addConfigTemplate(newConfig));
+};
+
+module.exports.setTheme = setTheme;
+module.exports.listThemes = listThemes;
 module.exports.setVerbosity = setVerbosity;
 module.exports.generateAPIFrame = generateAPIFrame;
 module.exports.refreshAPI = refreshAPI;

--- a/src/utils.js
+++ b/src/utils.js
@@ -334,7 +334,7 @@ const listThemes = (gutenrc) => {
 /**
  * Create the a string format of the config file with the passed
  * in object as the export value of configData
- * @param { object } newConfig a JON formatted object containing the theme adjusted settings
+ * @param { string } newConfig stringified JSON of the desired config settings
  */
 const addConfigTemplate = newConfig => '/* eslint-disable quote-props */\n'
   + '/* eslint-disable quotes */\n'


### PR DESCRIPTION
Added theme usage instructions to the readme

Added themes to the CLI

Added a bada55 theme and a defualt theme

Made showing the fork me on github ribbon togglable in the gutenConfig.

Made the sidebar heading, main heading, and document title editable from gutenconfig

Added inline styles that can be set using gutenConfig to specify colors

Added theme listing function that lists all available themes

Added theme setting function that overwrites gutenConfig.js with the settings from the theme of choice